### PR TITLE
Hide native browser marker

### DIFF
--- a/src/details-element-polyfill/polyfill.sass
+++ b/src/details-element-polyfill/polyfill.sass
@@ -11,6 +11,9 @@ details
       font-size: 0.6rem
       cursor: default
 
+    &::-webkit-details-marker {
+      display: none;
+
   &[open] > summary
     &::before
       content: '▼'


### PR DESCRIPTION
Some browsers support details/summary natively and add their own icon (notably Firefox).