### PR TITLE
Element.closest impl: use parentNode rather than parentElement

### DIFF
--- a/src/details-element-polyfill/polyfill.coffee.erb
+++ b/src/details-element-polyfill/polyfill.coffee.erb
@@ -149,7 +149,7 @@ findClosestElementWithTagName = do ->
         if element.tagName is tagName
           return element
         else
-          element = element.parentElement
+          element = element.parentNode
 
 triggerToggle = (element) ->
   event = document.createEvent("Events")


### PR DESCRIPTION
This allows clicks to work as expected in inline SVG elements.

Without this, if you put an inline SVG in the `<summary>` tag and click it, nothing will happen. This is because `parentElement` is undefined on SVG elements (at least in IE11, where I'm using this polyfill).