### PR TITLE
Remove unused summary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,6 @@ function polyfillProperties() {
 
 function polyfillToggle() {
   onTogglingTrigger(element => {
-    const summary = element.querySelector("summary")
     if (element.hasAttribute("open")) {
       element.removeAttribute("open")
       element.setAttribute("aria-expanded", false)


### PR DESCRIPTION
The `summary` variable is never referenced in its scope and has no apparent purpose.