### PR TITLE
Fix a typo that causes an error in Safari 9

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ function polyfillToggleEvent() {
       forEach.call(mutations, mutation => {
         const { target, attributeName } = mutation
         if (target.tagName == "DETAILS" && attributeName == "open") {
-          triggerToggle(toggle)
+          triggerToggle(target)
         }
       })
     }).observe(document.documentElement, {


### PR DESCRIPTION
`toggle` is not a variable in that scope. Looks like it should've been `target`. 

This fixes a `Can't find variable: toggle` error I've been getting in Safari 9.

Thank you!